### PR TITLE
Rename app to aws-security-czar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp
 mkmf.log
 
 config/*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ mkmf.log
 
 config/*
 .idea
+.DS_Store

--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,4 +1,4 @@
-github_repo: sportngin/ec2-security-czar
+github_repo: sportngin/aws-security-czar
 semantic_versioning: true
 branches_to_keep:
 - master

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,2 +1,2 @@
-ec2-security-czar
+aws-security-czar
 

--- a/.soyuz.yml
+++ b/.soyuz.yml
@@ -2,10 +2,10 @@ defaults:
   deploy_cmd: gem push *.gem
   before_deploy_cmds:
     - op tag-release
-    - sed -i '' -e "s/\".*/\"$(git tag | tail -1 | sed s/v//)\"/" lib/ec2-security-czar/version.rb
-    - git add  lib/ec2-security-czar/version.rb
+    - sed -i '' -e "s/\".*/\"$(git tag | tail -1 | sed s/v//)\"/" lib/aws-security-czar/version.rb
+    - git add  lib/aws-security-czar/version.rb
     - git commit -m "Version Bump" && git push
-    - gem build ec2-security-czar.gemspec
+    - gem build aws-security-czar.gemspec
   after_deploy_cmds:
     - rm *.gem
 environments:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: ruby
 rvm:
   - 2.0
-  - 2.1
-  - 1.9.3
+  - 2.2
+  - 2.3
 script: bundle exec rspec
-matrix:
-  include:
-    - rvm: jruby-19mode # JRuby in 1.9 mode
-      env: JRUBY_OPTS="--1.9 -Xcext.enabled=true"
-  allow_failures:
-    - rvm: jruby-19mode
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in ec2-security-czar.gemspec
+# Specify your gem's dependencies in aws-security-czar.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ec2SecurityCzar
+# AwsSecurityCzar
 
 Manages changes to AWS EC2 Security Groups via YAML files.
 
@@ -6,7 +6,7 @@ Manages changes to AWS EC2 Security Groups via YAML files.
 
 Add this line to your application's Gemfile:
 
-    gem 'ec2-security-czar'
+    gem 'aws-security-czar'
 
 And then execute:
 
@@ -14,7 +14,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install ec2-security-czar
+    $ gem install aws-security-czar
 
 ## Setup
 #### Install gems:
@@ -66,12 +66,12 @@ outbound: # Inbound and outbound rules are separate
 #### Update the rules on AWS:
 
 ```
-ec2-security-czar update [env_name]
+aws-security-czar update [env_name]
 ```
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/ec2-security-czar/fork )
+1. Fork it ( https://github.com/[my-github-username]/aws-security-czar/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/aws-security-czar.gemspec
+++ b/aws-security-czar.gemspec
@@ -1,13 +1,13 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ec2-security-czar/version'
+require 'aws-security-czar/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "ec2-security-czar"
-  spec.version       = Ec2SecurityCzar::VERSION
-  spec.authors       = ["Ian Ehlert"]
-  spec.email         = ["ehlertij@gmail.com"]
+  spec.name          = "aws-security-czar"
+  spec.version       = AwsSecurityCzar::VERSION
+  spec.authors       = ["Ian Ehlert", "Matt Krieger"]
+  spec.email         = ["platform-ops@sportsengine.com"]
   spec.summary       = %q{Rule manager for EC2 Security Groups.}
   spec.description   = %q{Manages your EC2 security groups using YAML config files.}
   spec.homepage      = "https://github.com/sportngin/ec2-security-czar"

--- a/aws-security-czar.gemspec
+++ b/aws-security-czar.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "3.0.0.beta2"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "guard", "~> 2.5.0"
+  spec.add_development_dependency "guard-rspec", "~> 4.2"
   spec.add_development_dependency "terminal-notifier-guard"
   spec.add_development_dependency "simplecov"
 end

--- a/bin/aws-security-czar
+++ b/bin/aws-security-czar
@@ -1,12 +1,12 @@
 #! /usr/bin/env ruby
 require 'rubygems'
 require 'gli'
-require 'ec2_security_czar'
+require 'aws_security_czar'
 
 include GLI::App
 
 program_desc 'Command Line Ec2 Security Group Manager'
-version Ec2SecurityCzar::VERSION
+version AwsSecurityCzar::VERSION
 
 wrap_help_text :verbatim
 
@@ -26,7 +26,7 @@ command :update do |c|
   c.flag [:t, :token], :desc => "AWS MFA Auth Token, Requires mfa_serial_number to be set in the aws config"
   c.flag [:r, :region], :desc => "AWS Region to apply updates in, ex. 'us-west-2', defaults to 'us-east-1'"
   c.action do |global_options, options, args|
-   Ec2SecurityCzar::Base.new(args.first, global_options.merge(options)).update_security_groups
+   AwsSecurityCzar::Base.new(args.first, global_options.merge(options)).update_security_groups
   end
 end
 

--- a/bin/awssec
+++ b/bin/awssec
@@ -1,0 +1,1 @@
+aws-security-czar

--- a/lib/aws-security-czar/base.rb
+++ b/lib/aws-security-czar/base.rb
@@ -2,7 +2,7 @@ require 'aws-sdk'
 require 'yaml'
 require 'hashie'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   class AwsConfig < Hash
     include Hashie::Extensions::IndifferentAccess
   end

--- a/lib/aws-security-czar/rule.rb
+++ b/lib/aws-security-czar/rule.rb
@@ -1,6 +1,6 @@
 require 'highline/import'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   class Rule
 
     attr_accessor :protocol, :port_range, :ip, :group, :egress

--- a/lib/aws-security-czar/security_group.rb
+++ b/lib/aws-security-czar/security_group.rb
@@ -3,7 +3,7 @@ require 'erb'
 require 'hashie'
 require 'highline/import'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   class SecurityGroupConfig < Hash
     include Hashie::Extensions::IndifferentAccess
   end

--- a/lib/aws-security-czar/version.rb
+++ b/lib/aws-security-czar/version.rb
@@ -1,3 +1,3 @@
-module Ec2SecurityCzar
+module AwsSecurityCzar
   VERSION = "1.0.0"
 end

--- a/lib/aws_security_czar.rb
+++ b/lib/aws_security_czar.rb
@@ -1,0 +1,4 @@
+require_relative 'aws-security-czar/base'
+require_relative 'aws-security-czar/security_group'
+require_relative 'aws-security-czar/rule'
+require_relative 'aws-security-czar/version'

--- a/lib/ec2_security_czar.rb
+++ b/lib/ec2_security_czar.rb
@@ -1,4 +1,0 @@
-require_relative 'ec2-security-czar/base'
-require_relative 'ec2-security-czar/security_group'
-require_relative 'ec2-security-czar/rule'
-require_relative 'ec2-security-czar/version'

--- a/spec/lib/ec2-security-czar/base_spec.rb
+++ b/spec/lib/ec2-security-czar/base_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper.rb'
-require 'ec2-security-czar/base'
+require 'aws-security-czar/base'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   describe Base do
     let(:access_key){ 'aws-key' }
     let(:secret_access_key){ 'aws-secret-key' }

--- a/spec/lib/ec2-security-czar/rule_spec.rb
+++ b/spec/lib/ec2-security-czar/rule_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper.rb'
-require 'ec2-security-czar/rule'
-require 'ec2-security-czar/security_group'
+require 'aws-security-czar/rule'
+require 'aws-security-czar/security_group'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   describe Rule do
     let(:direction) { :outbound }
     let(:ip_range) { '0.0.0.0/0' }

--- a/spec/lib/ec2-security-czar/security_group_spec.rb
+++ b/spec/lib/ec2-security-czar/security_group_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper.rb'
-require 'ec2-security-czar/security_group'
+require 'aws-security-czar/security_group'
 
-module Ec2SecurityCzar
+module AwsSecurityCzar
   describe SecurityGroup do
     let(:outbound_rule) {
       {


### PR DESCRIPTION
Once this is merged, the repo name should be changed to `aws-security-czar` as well so that the octopolo config works as expected.